### PR TITLE
Normalize CSV newline markers

### DIFF
--- a/main3.py
+++ b/main3.py
@@ -214,7 +214,7 @@ def generate_content_cards(row_data, index):
     highlight_font = ImageFont.truetype(HIGHLIGHT_FONT_PATH, 44)
     highlight_color = (255, 223, 100)
 
-    opis_formatted = re.sub(r'(\s)(?=\d+\.)', r'\n', opis)
+    opis_formatted = re.sub(r'(\s)(?=\d+\.)', '\n', opis)
     text_blocks = [block.strip() for block in opis_formatted.split('\n') if block.strip()]
 
     pages = []
@@ -367,6 +367,10 @@ def main():
         with open(csv_file, mode='r', newline='', encoding='utf-8-sig') as f:
             reader = csv.DictReader(row for row in f if row.strip())
             for i, row in enumerate(reader):
+                row = {
+                    key: value.replace('\\n', '\n') if isinstance(value, str) else value
+                    for key, value in row.items()
+                }
                 print(f"\n--- Przetwarzanie artykułu #{i}: {row.get('Tytuł', '')} ---")
                 if row.get('Kategoria') == 'Trendy cen':
                     generate_ranking_cards(row, i)


### PR DESCRIPTION
## Summary
- replace literal `\n` escape sequences with actual newlines for every CSV row before generating slides so paragraph logic can work on real line breaks
- ensure numbered list detection injects true newline characters rather than escaped sequences so downstream helpers split content correctly

## Testing
- python - <<'PY'
import csv
import re
from pathlib import Path
import main3

Path(main3.OUTPUT_DIR).mkdir(exist_ok=True)

with open('sample_input.csv', newline='', encoding='utf-8-sig') as f:
    reader = csv.DictReader(row for row in f if row.strip())
    for i, row in enumerate(reader):
        row = {
            key: value.replace('\\n', '\n') if isinstance(value, str) else value
            for key, value in row.items()
        }
        print(f"Row {i} title: {row.get('Tytuł')}")
        opis = row.get('Opis', '')
        opis_formatted = re.sub(r'(\s)(?=\d+\.)', '\n', opis)
        text_blocks = [block.strip() for block in opis_formatted.split('\n') if block.strip()]
        print('  text_blocks:', text_blocks)
        if row.get('Kategoria') == 'Trendy cen':
            list_items = re.findall(r'(\d+\.\s.*)', opis)
            print('  ranking items:', list_items)
            main3.generate_ranking_cards(row, i)
        else:
            main3.generate_content_cards(row, i)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ca5c4a2ecc832fa0040eab74415950