### PR TITLE
Update README with current CSV schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Skrypt generuje infografiki na potrzeby mediów społecznościowych na podstawie danych z pliku CSV.
 
+### Schemat pliku CSV
+Plik wejściowy powinien zawierać kolumny: `Tytul`, `Kategoria`, `Grafika`, `Tło`, `Logo`, `Opis`, `Źródło`.
+- Wartość w kolumnie `Tło` wskazuje adres URL grafiki tła używanej na planszy.
+- Kolumna `Grafika` zawiera adresy URL grafik kart; zapisuje się je w niej w postaci listy oddzielonej średnikiem (`;`).
+- Pozostałe kolumny (`Tytul`, `Kategoria`, `Logo`, `Opis`, `Źródło`) są wykorzystywane do wypełnienia treści karty.
+
 ### Ładowanie grafik
-
-Kolumna `Grafika` obsługuje teraz wiele adresów URL oddzielonych średnikiem (`;`).
-
-- pierwszy adres służy jako tło planszy,
-- kolejne adresy (jeśli występują) są wykorzystywane jako grafiki kart przy generowaniu rankingów w kategorii **Trendy cen**.
-
-Osobna kolumna `Karty_Grafiki` nie jest już potrzebna.
+Każdy adres umieszczony w kolumnie `Grafika` jest wykorzystywany wyłącznie jako grafika karty zarówno dla stron z treściami, jak i rankingów w kategorii **Trendy cen**.
+Grafika tła planszy jest ładowana z adresu z kolumny `Tło`.


### PR DESCRIPTION
## Summary
- document the current CSV column schema including the dedicated `Tło` background field
- clarify that `Grafika` entries are only used for card images on content and ranking pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb9f3d1e8832f928a610a0d3af6c8