### PR TITLE
Use local logo asset in common elements

### DIFF
--- a/main3.py
+++ b/main3.py
@@ -450,17 +450,16 @@ def add_common_elements(img, row_data, page_num, total_pages):
         banner.thumbnail((300, 80), Image.Resampling.LANCZOS)
         img.paste(banner, (WIDTH - PADDING - banner.width, HEIGHT - FOOTER_HEIGHT + 40), banner)
 
-    logo_source = (row_data.get("Logo") or "").strip()
+    logo_path = "PTCG.png"
     logo_img = None
 
-    if logo_source:
-        if logo_source.startswith("http"):
-            logo_img = fetch_image_from_url(logo_source)
-        elif os.path.exists(logo_source):
-            logo_img = Image.open(logo_source).convert("RGBA")
-
-    if logo_img is None and os.path.exists("PTCG.png"):
-        logo_img = Image.open("PTCG.png").convert("RGBA")
+    if os.path.exists(logo_path):
+        try:
+            logo_img = Image.open(logo_path).convert("RGBA")
+        except Exception as exc:
+            print(f"Błąd podczas ładowania logo z {logo_path}: {exc}")
+    else:
+        print(f"Ostrzeżenie: Brak pliku logo {logo_path}, pomijam wyświetlanie logo.")
 
     if logo_img:
         logo_img.thumbnail((200, 60), Image.Resampling.LANCZOS)


### PR DESCRIPTION
## Summary
- always attempt to load the shared PTCG.png logo instead of reading logo paths from CSV rows
- add error logging when the local logo file is missing or cannot be opened

## Testing
- python -m compileall main3.py

------
https://chatgpt.com/codex/tasks/task_e_68cd007940cc832fb8e0ad749768a8dc